### PR TITLE
Tweak CSS for smaller viewports

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -1,11 +1,13 @@
-#top-panel-wrapper, #menu-panel-wrapper, #spacer-widget {
-	display: none!important;
+#top-panel-wrapper,
+#menu-panel-wrapper,
+#spacer-widget {
+  display: none !important;
 }
 
 #main-panel {
-  top: 0px!important;
-  height: 100%!important;
-	max-width: unset!important;
+  top: 0px !important;
+  height: 100% !important;
+  max-width: unset !important;
 }
 
 .jp-CodeConsole-promptCell .jp-InputPrompt {
@@ -19,4 +21,20 @@
   font-size: var(--jp-ui-font-size0);
   padding: 0 var(--jp-console-padding) 0 0;
   color: var(--jp-ui-font-color0);
+}
+
+.jp-InputPrompt {
+  flex: 0 0 42px;
+}
+
+.jp-CodeConsole-input .jp-InputCollapser {
+  display: none;
+}
+
+.jp-InputArea {
+  flex-direction: row;
+}
+
+.jp-OutputArea-child {
+  flex-direction: row;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -35,6 +35,11 @@
   flex-direction: row;
 }
 
+.jp-InputArea-editor,
+.jp-OutputArea-child .jp-OutputArea-output {
+  margin-left: unset;
+}
+
 .jp-OutputArea-child {
   flex-direction: row;
 }


### PR DESCRIPTION
Fixes #13 

So the prompts stay aligned on a mobile layout, for example:

![image](https://user-images.githubusercontent.com/591645/152297521-a4faf627-3d8d-4c10-b07e-91104e02112a.png)

