### PR TITLE
Disable `jupyterlab-plotly` (widgets) plugin

### DIFF
--- a/jupyter-lite.ipynb
+++ b/jupyter-lite.ipynb
@@ -1,0 +1,35 @@
+{
+  "metadata": {
+    "jupyter-lite": {
+      "jupyter-config-data": {}
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "python",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8"
+    },
+    "kernelspec": {
+      "name": "python",
+      "display_name": "Pyolite",
+      "language": "python"
+    }
+  },
+  "nbformat_minor": 4,
+  "nbformat": 4,
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": "",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -5,7 +5,8 @@
     "appUrl": "./retro",
     "collaborative": true,
     "disabledExtensions": [
-      "@jupyterlite/javascript-kernel-extension"
+      "@jupyterlite/javascript-kernel-extension",
+      "jupyterlab-plotly"
     ]
   }
 }

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -5,6 +5,7 @@
     "appUrl": "./retro",
     "collaborative": true,
     "disabledExtensions": [
+      "@jupyter-widgets/jupyterlab-manager",
       "@jupyterlite/javascript-kernel-extension",
       "jupyterlab-plotly"
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,4 @@ build_cmd = "build:prod"
 npm = ["jlpm"]
 
 [tool.check-manifest]
-ignore = ["replite/labextension/**", "yarn.lock", ".*", "package-lock.json", "deploy.sh", "requirements-deploy.txt", "jupyter-lite.json"]
+ignore = ["replite/labextension/**", "yarn.lock", ".*", "package-lock.json", "deploy.sh", "requirements-deploy.txt", "jupyter-lite.json", "jupyter-lite.ipynb"]

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,3 +1,4 @@
+ipywidgets~=7.6
 jupyterlab~=3.2.8
 jupyterlite==0.1.0a20
 jupyterlab-fasta>=3,<4


### PR DESCRIPTION
Widgets are not supported in code consoles yet (https://github.com/jupyter-widgets/ipywidgets/pull/3004).

This should help fix the following errors logged in the dev tools console:

![image](https://user-images.githubusercontent.com/591645/152301591-099bc15e-0e58-4da9-9d09-c0778c251948.png)
