### PR TITLE
Update to micromamba `0.21.0`

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,8 +6,7 @@ set -xeu
 # bootstrap the environment
 yum install tar wget || true
 
-export MAMBA_VERSION=0.20.0
-export ZSH_VERSION=""
+export MAMBA_VERSION=0.21.0
 URL="https://anaconda.org/conda-forge/micromamba/${MAMBA_VERSION}/download/linux-64/micromamba-${MAMBA_VERSION}-0.tar.bz2"
 wget -qO- ${URL} | tar -xvj bin/micromamba
 


### PR DESCRIPTION
This should fix the `ZSH_VERSION` issue when running the deploy script with `-u`.