### PR TITLE
Allow some code to be silently pre-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The toolbar can be enabled (opt-in) to add a couple of useful buttons:
 
 ### Auto execute code on startup
 
-Custom starter code can automatically be executed on startup:
+Custom starter code can automatically be executed on startup and shown as the first cell using the `code` parameter:
 
 ```html
 <iframe src="https://replite.vercel.app/retro/consoles?kernel=python&code=import numpy as np" width="100%" height="100%">
@@ -47,6 +47,13 @@ Custom starter code can automatically be executed on startup:
 ```
 
 https://user-images.githubusercontent.com/591645/152204519-7980e9f6-ef56-4263-bb79-4fcf3e4fd2be.mp4
+
+or starter code can be silently pre-run with the `prerun` parameter:
+
+```html
+<iframe src="https://replite.vercel.app/retro/consoles?kernel=python&prerun=import micropip%0Aawait micropip.install('xarray')&code=import xarray as xr" width="100%" height="100%">
+</iframe>
+```
 
 ### Themes
 

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,6 +1,6 @@
 ipywidgets~=7.6
 jupyterlab~=3.2.9
-jupyterlite==0.1.0a21
+jupyterlite==0.1.0a23
 jupyterlab-fasta>=3,<4
 jupyterlab-geojson>=3,<4
 plotly>=5,<6

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ const parameters: JupyterFrontEndPlugin<void> = {
     const search = window.location.search;
     const urlParams = new URLSearchParams(search);
     const code = urlParams.getAll('code');
+    const install = urlParams.getAll('install');
     const kernel = urlParams.get('kernel');
     const theme = urlParams.get('theme')?.trim();
     const toolbar = urlParams.get('toolbar');
@@ -162,6 +163,14 @@ const parameters: JupyterFrontEndPlugin<void> = {
         Dialog.tracker.widgetAdded.connect(hideFirstDialog);
 
         await console.sessionContext.changeKernel({ name: kernel });
+      }
+
+      if (install) {
+        await console.sessionContext.ready;
+        console.inject('import micropip');
+        install[0].split(',').forEach(pckg => window.console.log(pckg));
+        install[0].split(',').forEach(pckg => console.inject(`await micropip.install('${pckg}')`));
+        console.clear();
       }
 
       if (code) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,8 +167,9 @@ const parameters: JupyterFrontEndPlugin<void> = {
 
       if (prerun[0]) {
         await console.sessionContext.ready;
-        prerun.forEach(line => console.inject(line));
-        console.clear();
+        prerun.forEach(line =>
+          console.sessionContext.session?.kernel?.requestExecute({ code: line,
+          silent: true, store_history: false}));
       }
 
       if (code) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,6 @@ const parameters: JupyterFrontEndPlugin<void> = {
       if (install) {
         await console.sessionContext.ready;
         console.inject('import micropip');
-        install[0].split(',').forEach(pckg => window.console.log(pckg));
         install[0].split(',').forEach(pckg => console.inject(`await micropip.install('${pckg}')`));
         console.clear();
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ const parameters: JupyterFrontEndPlugin<void> = {
     const search = window.location.search;
     const urlParams = new URLSearchParams(search);
     const code = urlParams.getAll('code');
-    const install = urlParams.getAll('install');
+    const prerun = urlParams.getAll('prerun');
     const kernel = urlParams.get('kernel');
     const theme = urlParams.get('theme')?.trim();
     const toolbar = urlParams.get('toolbar');
@@ -165,10 +165,9 @@ const parameters: JupyterFrontEndPlugin<void> = {
         await console.sessionContext.changeKernel({ name: kernel });
       }
 
-      if (install[0]) {
+      if (prerun[0]) {
         await console.sessionContext.ready;
-        console.inject('import micropip');
-        install[0].split(',').forEach(pckg => console.inject(`await micropip.install('${pckg}')`));
+        prerun.forEach(line => console.inject(line));
         console.clear();
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,7 @@ const parameters: JupyterFrontEndPlugin<void> = {
         await console.sessionContext.changeKernel({ name: kernel });
       }
 
-      if (install) {
+      if (install[0]) {
         await console.sessionContext.ready;
         console.inject('import micropip');
         install[0].split(',').forEach(pckg => console.inject(`await micropip.install('${pckg}')`));


### PR DESCRIPTION
Hi,

Just found this repository and it looks great! Inspired by your PRs to `numpy` and `sympy` to use this REPL to allow people to try out code in documentation pages, I was interested in using this for some of my code. However, for packages that aren't part of `pyodide` directly, users would have to first do something like
```
import micropip
await micropip.install('PACKAGE')
```
before they can `import PACKAGE`. That would be confusing for users who don't know `pyodide`. My understanding is that `pyodide` does not want to include Python packages that have pure Python wheels available on PyPI, so this would be an issue for many packages.

This quick PR allows for an `install` URL parameter that lists a set of packages to quietly install with `micropip` (I wasn't sure whether I should use `micropip` or `piplite`, but both work). It works both with lists of packages (`&install=kimmy,scipy`) or with wheel URLS (`&install=https://astro.utoronto.ca/~bovy/galpywheels/galpy-1.8.0.dev0-py3-none-any.whl&code=import%20galpy`) .

I don't have any prior experience with TypeScript or the Jupyter backend, so there might be better ways to do this, but injecting the code and removing the cell seems to do what I want (I couldn't figure out how to just have the kernel execute a bit of code...).

This works locally, but I could push a version somewhere to illustrate use better if necessary (and can add to CHANGELOG and what not if you're inclined to accept this PR).

Thanks!

Edit: Full example using my galaxy chemical evolution code [`kimmy`](https://github.com/jobovy/kimmy) on the Vercel deployment [here](https://replite-git-fork-jobovy-quiet-installs-jtpx.vercel.app/retro/consoles/?kernel=python&prerun=import%20micropip%0Aawait%20micropip.install([%27scipy%27,%27kimmy%27])&code=import%20kimmy%0Aimport%20numpy%0Aimport%20astropy.units%20as%20u%0Afrom%20matplotlib%20import%20pyplot%20as%20plt%0A%matplotlib%20inline%0Aoz=%20kimmy.OneZone()%0Ats=%20numpy.linspace(0.001,10.,1001)*u.Gyr%0Aoz.initial()%0Aplt.plot(oz.Fe_H(ts),oz.O_Fe(ts))%0Aplt.xlabel(%27%5BFe/H%5D%27)%0Aplt.ylabel(%27%5Ba/Fe%5D%27)).